### PR TITLE
Dedicated kubectl Namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
 .terraform.lock.hcl
+
+# Kubernetes cluster configs
+.kubeconfig

--- a/cronjobs.tf
+++ b/cronjobs.tf
@@ -6,20 +6,22 @@ module "nginx_scale_up" {
   source = "./scale-hpa-replicas"
   name ="nginx-scale-up"
   horizontal-pod-autoscaler-name = local.demo_name
-  namespace = module.irsa.namespace
+  horizontal-pod-autoscaler-namespace = kubernetes_namespace.nginx-demo.metadata[0].name
   schedule = "0,20,40 * * * *"
   min-replicas = 10
   kubectl-repo = aws_ecr_repository.cluster_repo.repository_url
   service-account-name = "kubectl-hpa"
+  service-account-namespace = module.irsa.namespace
 }
 
 module "nginx_scale_down" {
   source = "./scale-hpa-replicas"
   name ="nginx-scale-down"
   horizontal-pod-autoscaler-name = local.demo_name
-  namespace = module.irsa.namespace
+  horizontal-pod-autoscaler-namespace = kubernetes_namespace.nginx-demo.metadata[0].name
   schedule = "10,30,50 * * * *"
   min-replicas = 2
   kubectl-repo = aws_ecr_repository.cluster_repo.repository_url
   service-account-name = "kubectl-hpa"
+  service-account-namespace = module.irsa.namespace
 }

--- a/main.tf
+++ b/main.tf
@@ -291,7 +291,7 @@ resource "kubectl_manifest" "karpenter_provisioner" {
 
 module "irsa" {
   source                     = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/irsa?ref=v4.24.0"
-  kubernetes_namespace       = local.demo_namespace
+  kubernetes_namespace       = "kubectl"
   kubernetes_service_account = "kubectl-hpa"
   irsa_iam_policies          = [aws_iam_policy.hpa_irsa_policy.arn]
   eks_cluster_id             = module.eks_blueprints.eks_cluster_id

--- a/nginx-demo.tf
+++ b/nginx-demo.tf
@@ -1,7 +1,13 @@
+resource "kubernetes_namespace" "nginx-demo" {
+  metadata {
+    name      = local.demo_namespace
+  } 
+}
+
 resource "kubernetes_deployment" "nginx_demo" {
   metadata {
     name      = local.demo_name
-    namespace = module.irsa.namespace
+    namespace = kubernetes_namespace.nginx-demo.metadata[0].name
     labels = {
       app = local.demo_name
     }
@@ -66,7 +72,7 @@ resource "kubernetes_deployment" "nginx_demo" {
 resource "kubernetes_service" "nginx_demo" {
   metadata {
     name      = local.demo_name
-    namespace = module.irsa.namespace
+    namespace = kubernetes_namespace.nginx-demo.metadata[0].name
   }
   spec {
     selector = {
@@ -83,7 +89,7 @@ resource "kubernetes_service" "nginx_demo" {
 resource "kubernetes_horizontal_pod_autoscaler" "nginx_demo" {
   metadata {
     name      = local.demo_name
-    namespace = module.irsa.namespace
+    namespace = kubernetes_namespace.nginx-demo.metadata[0].name
   }
   spec {
     min_replicas = 2

--- a/scale-hpa-replicas/main.tf
+++ b/scale-hpa-replicas/main.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_cron_job" "scale_min_replicas" {
   metadata {
     name      = var.name
-    namespace = var.namespace
+    namespace = var.service-account-namespace
   }
   spec {
     concurrency_policy            = "Replace"
@@ -22,7 +22,7 @@ resource "kubernetes_cron_job" "scale_min_replicas" {
             container {
               name    = "kubectl"
               image   = "${var.kubectl-repo}:latest"
-              command = ["/bin/sh", "-c", "kubectl patch hpa ${var.horizontal-pod-autoscaler-name} -n ${var.namespace} -p '{\"spec\":{\"minReplicas\": ${var.min-replicas}}}'"]
+              command = ["/bin/sh", "-c", "kubectl patch hpa ${var.horizontal-pod-autoscaler-name} -n ${var.horizontal-pod-autoscaler-namespace} -p '{\"spec\":{\"minReplicas\": ${var.min-replicas}}}'"]
             }
           }
         }

--- a/scale-hpa-replicas/variables.tf
+++ b/scale-hpa-replicas/variables.tf
@@ -4,7 +4,7 @@ variable name {
 variable horizontal-pod-autoscaler-name {
     type = string
 }
-variable namespace {
+variable horizontal-pod-autoscaler-namespace {
     type = string
 }
 variable schedule {
@@ -17,5 +17,8 @@ variable kubectl-repo {
     type = string
 }
 variable service-account-name {
+    type = string
+}
+variable service-account-namespace {
     type = string
 }


### PR DESCRIPTION
Run CronJobs in the dedicated kubectl namespace to use the ClusterRole service account in that namespace, but modify the horizontal pod autoscaler in it's own dedicated namespace in the CronJob command line.
This allows for the servicing of horizontal pod autoscalers in multiple namespaces with a single service account and ClusterRole/ClusterRoleBinding.